### PR TITLE
Export from_tokio_resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "dmarc"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "addr",
  "cfdkim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dmarc"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Sven Sauleau <sven@cloudflare.com>"]
 description = "DMARC (RFC7489) implementation"

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -43,7 +43,7 @@ impl Lookup for TokioAsyncResolverWrapper {
     }
 }
 
-pub(crate) fn from_tokio_resolver(resolver: TokioAsyncResolver) -> Arc<dyn Lookup> {
+pub fn from_tokio_resolver(resolver: TokioAsyncResolver) -> Arc<dyn Lookup> {
     Arc::new(TokioAsyncResolverWrapper { inner: resolver })
 }
 


### PR DESCRIPTION
from_tokio_resolver was only available inside the current crate
but we need it to supply our own resolver.